### PR TITLE
Improve student activity registration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,14 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 ---
 
+## Backend Testing
+
+Run the FastAPI backend tests from the repository root:
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```
+
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_participant(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Team basketball training and inter-school matches",
+        "schedule": "Mondays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Soccer Club": {
+        "description": "Soccer drills, teamwork, and friendly competitions",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 22,
+        "participants": ["ava@mergington.edu", "ethan@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore drawing, painting, and mixed media projects",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["mia@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Drama Society": {
+        "description": "Practice acting, stage performance, and script reading",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["amelia@mergington.edu", "henry@mergington.edu"]
+    },
+    "Debate Club": {
+        "description": "Develop public speaking and critical argument skills",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 14,
+        "participants": ["charlotte@mergington.edu", "jack@mergington.edu"]
+    },
+    "Math Olympiad Prep": {
+        "description": "Advanced problem-solving for math competitions",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["isabella@mergington.edu", "alexander@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,11 +7,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,35 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsList = details.participants
+          .map(
+            (participant) => `
+              <li>
+                <span class="participant-email">${participant}</span>
+                <button
+                  type="button"
+                  class="participant-delete"
+                  data-activity="${name}"
+                  data-email="${participant}"
+                  aria-label="Unregister ${participant} from ${name}"
+                  title="Unregister participant"
+                >🗑️</button>
+              </li>
+            `
+          )
+          .join("");
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p><strong>Participants (${details.participants.length}):</strong></p>
+            <ul class="participants-list">
+              ${participantsList || "<li>No participants yet</li>"}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -69,6 +93,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
       messageDiv.classList.remove("hidden");
 
+      if (response.ok) {
+        await fetchActivities();
+      }
+
       // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
@@ -78,6 +106,51 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".participant-delete");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = deleteButton.dataset.activity;
+    const email = deleteButton.dataset.email;
+
+    if (!activity || !email) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Failed to unregister participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -63,6 +63,12 @@ section h3 {
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.activity-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
 }
 
 .activity-card h4 {
@@ -72,6 +78,65 @@ section h3 {
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+.participants-section {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid #d7def5;
+  border-radius: 4px;
+  background-color: #eef2ff;
+}
+
+.participants-section p {
+  margin-bottom: 6px;
+}
+
+.participants-list {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+  color: #1f2d5a;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.participant-delete {
+  border: 1px solid #ef9a9a;
+  background-color: #ffebee;
+  color: #c62828;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, background-color 0.2s ease;
+  font-size: 14px;
+}
+
+.participant-delete:hover {
+  background-color: #ffcdd2;
+  transform: scale(1.05);
 }
 
 .form-group {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_activities = copy.deepcopy(activities)
+
+    yield
+
+    activities.clear()
+    activities.update(copy.deepcopy(original_activities))

--- a/tests/test_activities_read.py
+++ b/tests/test_activities_read.py
@@ -1,0 +1,18 @@
+def test_get_activities_returns_activity_mapping(client):
+    # Arrange
+    expected_activity = "Chess Club"
+
+    # Act
+    response = client.get("/activities")
+    payload = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(payload, dict)
+    assert expected_activity in payload
+    assert {
+        "description",
+        "schedule",
+        "max_participants",
+        "participants",
+    }.issubset(payload[expected_activity])

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,59 @@
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    new_email = "newstudent@mergington.edu"
+
+    # Act
+    signup_response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": new_email},
+    )
+    activities_response = client.get("/activities")
+
+    # Assert
+    assert signup_response.status_code == 200
+    assert signup_response.json()["message"] == f"Signed up {new_email} for {activity_name}"
+    assert new_email in activities_response.json()[activity_name]["participants"]
+
+
+def test_signup_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": existing_email},
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_returns_not_found_for_missing_activity(client):
+    # Arrange
+    activity_name = "Nonexistent Club"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup",
+        params={"email": email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_requires_email_query_param(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup")
+
+    # Assert
+    assert response.status_code == 422

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,61 @@
+def test_unregister_removes_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    participant_email = "michael@mergington.edu"
+
+    # Act
+    unregister_response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": participant_email},
+    )
+    activities_response = client.get("/activities")
+
+    # Assert
+    assert unregister_response.status_code == 200
+    assert unregister_response.json()["message"] == (
+        f"Unregistered {participant_email} from {activity_name}"
+    )
+    assert participant_email not in activities_response.json()[activity_name]["participants"]
+
+
+def test_unregister_returns_not_found_for_missing_activity(client):
+    # Arrange
+    activity_name = "Nonexistent Club"
+    participant_email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": participant_email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_not_found_for_missing_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    missing_email = "not-registered@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/participants",
+        params={"email": missing_email},
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in this activity"
+
+
+def test_unregister_requires_email_query_param(client):
+    # Arrange
+    activity_name = "Chess Club"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/participants")
+
+    # Assert
+    assert response.status_code == 422


### PR DESCRIPTION
This pull request introduces several key improvements to the student activities app, including expanded activity options, participant management features, enhanced frontend interactivity, improved UI styling, and comprehensive backend testing. The most important changes are grouped below by theme:

**Backend Features and API Enhancements**

* Added multiple new activities to the `activities` data structure in `src/app.py`, expanding the available options for students.
* Introduced validation to prevent duplicate signups and added a new API endpoint to unregister participants from activities, improving participant management.

**Frontend Functionality and UI Improvements**

* Updated `src/static/app.js` to display participants for each activity, including an unregister button for each participant, and ensured that the activities list refreshes after signup or unregister actions. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R51) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R96-R99) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R112-R156)
* Enhanced the UI in `src/static/styles.css` by adding hover effects for activity cards and styling for participant lists and delete buttons, making the interface more user-friendly and visually appealing. [[1]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R66-R71) [[2]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R83-R141)

**Testing and Documentation**

* Added backend test documentation to `README.md` and implemented comprehensive pytest-based tests for activity listing, signup, and unregister endpoints, including fixtures for state reset and validation of edge cases. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R23) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R21) [[3]](diffhunk://#diff-d9241c08affe08c89824413c5cfd8c941731defd4f3b985e597df5a6358f2122R1-R18) [[4]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R59) [[5]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R61)